### PR TITLE
Fix audio feature lookup in track fetch

### DIFF
--- a/backend/routers/analytics.py
+++ b/backend/routers/analytics.py
@@ -132,8 +132,9 @@ async def get_playlist_tracks(
         
         tracks_data = tracks_response.json()
         track_ids = [item["track"]["id"] for item in tracks_data["items"] if item["track"]["id"]]
-        
+
         # Get audio features for all tracks
+        features_map = {}
         if track_ids:
             features_response = await client.get(
                 "https://api.spotify.com/v1/audio-features",


### PR DESCRIPTION
## Summary
- initialize features_map when fetching playlist tracks

## Testing
- `PYTHONPATH=. pytest tests/test_clustering.py::TestClusteringService::test_cluster_tracks_kmeans -q`
- `PYTHONPATH=. pytest tests/test_clustering.py -q` *(fails: UNIQUE constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_68578279936083248a45aae390825fe8